### PR TITLE
Remove placeholder configurations for Google Analytics and Disqus

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -22,11 +22,12 @@ defaultContentLanguageInSubdir = false
 
 ########################### Services #############################
 [services]
-[services.googleAnalytics]
-ID = 'G-MEASUREMENT_ID' # see https://gohugo.io/templates/internal/#configure-google-analytics
+# Disabled placeholder configurations - uncomment and configure when needed
+# [services.googleAnalytics]
+# ID = 'G-MEASUREMENT_ID' # see https://gohugo.io/templates/internal/#configure-google-analytics
 
-[services.disqus]
-shortname = 'themefisher-template' # we use disqus to show comments in blog posts . To install disqus please follow this tutorial https://portfolio.peter-baumgartner.net/2017/09/10/how-to-install-disqus-on-hugo/
+# [services.disqus]
+# shortname = 'themefisher-template' # we use disqus to show comments in blog posts . To install disqus please follow this tutorial https://portfolio.peter-baumgartner.net/2017/09/10/how-to-install-disqus-on-hugo/
 
 ########################## Permalinks ############################
 [permalinks.page]


### PR DESCRIPTION
Disables unused placeholder configurations that contained invalid/template values:
- Google Analytics: 'G-MEASUREMENT_ID' (not configured)
- Disqus: 'themefisher-template' (not configured)

These services are commented out and can be re-enabled when proper IDs are configured. This prevents potential confusion and ensures clean configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)