### PR TITLE
Add canonical URLs to prevent duplicate content issues

### DIFF
--- a/themes/hugoplate/layouts/partials/essentials/head.html
+++ b/themes/hugoplate/layouts/partials/essentials/head.html
@@ -8,6 +8,9 @@
 <!-- theme meta -->
 <meta name="theme-name" content="hugoplate" />
 
+<!-- canonical url -->
+<link rel="canonical" href="{{ .Permalink }}" />
+
 <!-- favicon -->
 {{ partialCached "favicon" . }}
 


### PR DESCRIPTION
Implements canonical link tags on all pages to help search engines identify the primary version of each page. This is critical for SEO to avoid duplicate content penalties.

Changes:
- Added <link rel="canonical"> tag to head.html
- Uses {{ .Permalink }} to generate correct absolute URLs
- Applies to all pages (homepage, posts, static pages)

Impact: Prevents duplicate content issues, improves search engine indexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)