### PR TITLE
Add JSON-LD Organization Schema for rich snippets

### DIFF
--- a/themes/hugoplate/layouts/partials/essentials/head.html
+++ b/themes/hugoplate/layouts/partials/essentials/head.html
@@ -27,6 +27,34 @@
 {{ partial "basic-seo.html" . }}
 
 
+<!-- JSON-LD Organization Schema -->
+{{ if .IsHome }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "{{ site.Title }}",
+  "url": "{{ site.BaseURL }}",
+  {{ with site.Params.logo }}"logo": "{{ site.BaseURL }}{{ . }}",{{ end }}
+  {{ with site.Params.metadata.description }}"description": "{{ . }}",{{ end }}
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "Adlerweg 6",
+    "addressLocality": "Wendelstein",
+    "postalCode": "90530",
+    "addressCountry": "DE"
+  },
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "+49 9129 1400929",
+    "contactType": "customer service",
+    "email": "post@unwritten.studio"
+  }
+}
+</script>
+{{ end }}
+
+
 <!-- custom script -->
 {{ partialCached "custom-script.html" . }}
 


### PR DESCRIPTION
Implements structured data (Schema.org) for the organization to enable rich snippets in Google search results. This helps search engines understand the business better and can lead to enhanced search result displays.

Schema includes:
- Organization name and URL
- Company logo
- Business description
- Physical address (Adlerweg 6, 90530 Wendelstein, DE)
- Contact information (phone, email)

The schema appears only on the homepage (using .IsHome check) as organization data should be defined once per site.

Impact: Enables rich snippets in search results, improves knowledge graph presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)