### PR TITLE
Phase 3: Improve alt text attributes for better accessibility and SEO

### DIFF
--- a/content/english/_index.md
+++ b/content/english/_index.md
@@ -48,8 +48,11 @@ partners:
   content: "Wir erschaffen aus starren Texten lebendige Gesprächspartner, die sich ganz auf ihre Nutzer einlassen. Von Unternehmenskommunikation über Experteninterviews bis hin zu kreativen Storytelling-Projekten entwickeln wir maßgeschneiderte Lösungen, die Menschen und Inhalte auf überraschende Weise ganz neu verbinden."
   partner_logo:
     - image: "/images/S._Fischer_Verlag_Logo.svg"
+      alt: "S. Fischer Verlag Partner Logo"
     - image: "/images/Hugendubel-Logo.svg"
+      alt: "Hugendubel Partner Logo"
     - image: "/images/OReilly_logo_black_rgb.svg"
+      alt: "O'Reilly Media Partner Logo"
 
 
 # Anwendungen

--- a/themes/hugoplate/layouts/index.html
+++ b/themes/hugoplate/layouts/index.html
@@ -118,7 +118,7 @@
           <div
             class="w-[86%] md:w-[190px] lg:w-[190px] h-[60px] md:h-[98px] lg:h-[98px] mx-auto bg-[url('/images/Glaskugel.png')] bg-cover bg-no-repeat bg-top flex justify-center items-end pb-4">
             <div class="w-1/2">
-              {{ partial "image" (dict "Src" .image "Alt" "brand" "Loading" "lazy" "Class" "w-full h-auto"
+              {{ partial "image" (dict "Src" .image "Alt" (.alt | default "Partner logo") "Loading" "lazy" "Class" "w-full h-auto"
               "DisplayXL" "260x" "DisplayMD" "360x" ) }}
             </div>
           </div>


### PR DESCRIPTION
Enhances image alt attributes to provide descriptive, meaningful text for screen readers and search engines.

Changes:
1. Add descriptive alt texts to partner logos in _index.md:
   - "S. Fischer Verlag Partner Logo"
   - "Hugendubel Partner Logo"
   - "O'Reilly Media Partner Logo"

2. Update index.html template to use dynamic alt text from YAML:
   - Partner logo partial now reads .alt from frontmatter
   - Fallback to "Partner logo" if not specified
   - Enables content-driven alt text management

Impact:
- ✅ Improved accessibility for screen reader users
- ✅ Better semantic SEO (partner recognition)
- ✅ WCAG 2.1 compliance for images
- ✅ Better maintainability (alt text in content, not code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)