### PR TITLE
Phase 3: Add pagination rel links for proper crawling of multi-page c…

### DIFF
--- a/themes/hugoplate/layouts/partials/essentials/head.html
+++ b/themes/hugoplate/layouts/partials/essentials/head.html
@@ -11,6 +11,16 @@
 <!-- canonical url -->
 <link rel="canonical" href="{{ .Permalink }}" />
 
+<!-- pagination rel links -->
+{{ if not .IsPage }}
+  {{ if .Paginator.HasPrev }}
+    <link rel="prev" href="{{ .Paginator.Prev.URL }}" />
+  {{ end }}
+  {{ if .Paginator.HasNext }}
+    <link rel="next" href="{{ .Paginator.Next.URL }}" />
+  {{ end }}
+{{ end }}
+
 <!-- favicon -->
 {{ partialCached "favicon" . }}
 


### PR DESCRIPTION
…ontent

Implements rel="prev" and rel="next" links to help search engines properly crawl and index paginated content (e.g., blog archives).

Changes:
- Add conditional pagination link generation in head.html
- Only applies to list/archive pages (not single pages)
- Automatically generates prev/next links when pagination is available

Implementation:
- Uses {{ if not .IsPage }} to check for list pages only
- Prevents errors on single page templates
- Works with Hugo's built-in Paginator

Impact:
- ✅ Helps Google consolidate paginated series as a single unit
- ✅ Prevents duplicate content issues with paginated archives
- ✅ Improves crawl efficiency for multi-page content
- ✅ Better indexing for future blog/archive features

SEO Benefit: Prevents dilution of page rank across pagination pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)