### PR TITLE
Fix: Restore eager loading for Swiper carousel team images

### DIFF
--- a/themes/hugoplate/layouts/index.html
+++ b/themes/hugoplate/layouts/index.html
@@ -204,7 +204,7 @@
           {{ range $index, $team := .team }}
           <div class="swiper-slide relative">
             <div class="swiper-image">
-              {{ partial "image" (dict "Src" .image "Alt" "Swiper image" "Loading" "lazy" "Class" "w-full h-auto" "DisplayXL" "280x" "DisplayMD" "360x" ) }}
+              {{ partial "image" (dict "Src" .image "Alt" "Swiper image" "Loading" "eager" "Class" "w-full h-auto" "DisplayXL" "280x" "DisplayMD" "360x" ) }}
             </div>
             <div class="team-name absolute left-1/2 transform -translate-x-1/2 top-[105%] md:top-[105%] lg:top-[100%] xl:top-[105%] w-[150%] text-center transition-all duration-200 ease-[ease]">
               <p class="text-[#3e4447] font-tertiary text-lg tracking-wider mb-2">{{ .name | markdownify }}</p>


### PR DESCRIPTION
Reverts team member carousel images to loading="eager" to ensure proper carousel initialization.

Issue: Lazy loading prevented Swiper from correctly calculating slide dimensions on initial page load, causing only 4 team members to display instead of 5 on desktop.

Solution: Team images are Above-the-Fold carousel content and should load eagerly for proper UX. Lazy loading only beneficial for below-fold images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)