### PR TITLE
fix: Remove image fade-out to prevent white background bleed

### DIFF
--- a/assets/js/hero-video.js
+++ b/assets/js/hero-video.js
@@ -19,13 +19,11 @@
     return;
   }
 
-  var img = document.querySelector('#hero-media img');
-
+  // Fade video in only — do NOT fade the image out.
+  // If the image fades out, the white page background bleeds through and causes
+  // a visible brightness flash. The video at opacity 1 fully covers the image
+  // anyway, so the image never needs to disappear.
   video.addEventListener('playing', function () {
     video.style.opacity = '1';
-    if (img) {
-      img.style.transition = 'opacity 300ms ease';
-      img.style.opacity = '0';
-    }
   }, { once: true });
 }());


### PR DESCRIPTION
## Problem
Beim Crossfade waren Image (opacity 1→0) und Video (opacity 0→1) gleichzeitig animiert. Während das Bild ausblendet, schimmert der weiße Seiten-Hintergrund durch — sichtbares Aufhellen.

## Fix
Nur das Video blendet ein (opacity 0→1). Das Bild bleibt bei opacity 1 — das Video bei opacity 1 deckt es vollständig ab, das Bild muss nie verschwinden.

## Known Issue (low priority)
Sehr kurzer GPU Compositing Layer Promotion Flash genau beim Start der Transition — browser-seitiges Rendering-Artefakt, kaum wahrnehmbar ohne gezieltes Hinschauen.

## Testing
- [x] Lokal getestet in Chrome, Firefox, Brave
- [x] Hugo baut erfolgreich