### PR TITLE
fix: Increase line-height in showcase descriptions

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,7 @@ if (theme.fonts.font_family.secondary) {
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./hugo_stats.json"],
-  safelist: [{ pattern: /^swiper-/ }],
+  safelist: [{ pattern: /^swiper-/ }, "leading-relaxed", "leading-loose"],
   darkMode: "class",
   theme: {
     screens: {

--- a/themes/hugoplate/layouts/index.html
+++ b/themes/hugoplate/layouts/index.html
@@ -155,7 +155,7 @@
                 {{ .subtitle }}
               </a>
             </h3>
-            <p class="text-[#3e4447] font-tertiary text-sm lg:text-base tracking-wider">{{ .content }}</p>
+            <p class="text-[#3e4447] font-tertiary text-sm lg:text-base tracking-wider leading-relaxed">{{ .content }}</p>
           </div>
           <!-- Image - appears second on mobile, first on desktop -->
           <div class="flex-shrink-0 order-2 md:order-1">


### PR DESCRIPTION
## Summary

- `leading-relaxed` (line-height: 1.625) auf Showcase-Beschreibungstexte — war zu eng durch `text-sm`'s Default-Line-Height
- `leading-relaxed` und `leading-loose` zur Tailwind Safelist hinzugefügt, damit sie unabhängig vom hugo_stats.json-Scan kompiliert werden

## Test plan

- [ ] Showcase-Texte mit Zeilenumbruch wirken luftiger
- [ ] Keine anderen Sections betroffen

🤖 Generated with [Claude Code](https://claude.com/claude-code)