### PR TITLE
Refresh homepage content and feature section typography

### DIFF
--- a/content/english/_index.md
+++ b/content/english/_index.md
@@ -2,23 +2,22 @@
 # Banner
 banner:
   title: "Worte werden Welten"
-  content: "Stell dir vor, deine Texte könnten mit den Nutzern sprechen. Jede Frage beantworten. Jeden Kontext verstehen. Treue Gefährten entführen dich in ein packendes Abenteuer.\n
-  Aus starren Inhalten werden emotionale Erlebnisse. Nur deine Vorstellungskraft ist das Limit."
+  content: "Wir sind ein atmendes Labor. Wir stellen Hypothesen auf, bauen Prototypen, stellen sie live. Was dabei entsteht, sind keine fertigen Produkte — sondern lebendige Experimente, die man unmittelbar erleben kann."
   image: "/images/Titelbild_Blau_breit.jpg"
 
 # Features
 features:
   image: "/images/feature-image.jpg"
   features_list:
-    - title: "Personalisierte"
-      subtitle: "Erlebnisse"
-      content: "Der Nutzer erhält genau die Informationen, die zu seinem Wissensstand und Zielen passen"
-    - title: "Adaptive"
-      subtitle: "Inhalte"
-      content: "Statische Inhalte werden zu intelligenten Gesprächspartnern"
-    - title: "Natürliche"
-      subtitle: "Dialoge"
-      content: "Individuelle Gespräche, die sich vertraut und überraschend zugleich anfühlen"
+    - title: "Funke"
+      subtitle: "Zündung"
+      content: "Eine wilde Idee. Ein \"Was wäre, wenn?\" Moment, der nicht mehr loslässt. Jedes Experiment beginnt mit einem Funken, der nicht mehr ignoriert werden kann. Der Gestalt sucht."
+    - title: "Schmiede"
+      subtitle: "Rohbau"
+      content: "Kein Konzept in der Schublade. Wir bauen, was wir denken — roh, direkt, ohne Anspruch auf Perfektion. Ein erster Prototyp. Sofort live. Reale Interaktionen. Dann wissen wir mehr."
+    - title: "Sog"
+      subtitle: "Tiefgang"
+      content: "Was dabei entsteht, fesselt sofort. Nicht weil es schick aussieht, sondern weil es antwortet. Weil es sich anfühlt wie eine echte Begegnung, nicht wie eine glatte Oberfläche."
 
 # Quotes
 quotes:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,348 @@
+{{ define "main" }}
+<!-- Banner -->
+{{ with .Params.banner }}
+<section class="hero-section">
+  <div>
+    <div id="hero-media" class="relative">
+      {{ partial "image" (dict "Src" .image "Alt" "Banner image" "Loading" "eager" "Class" "w-full h-auto block" "DisplayMD" "1080x" "DisplayXL" "2000x" ) }}
+      {{ if site.Params.heroVideo }}
+      <video id="hero-video" autoplay muted playsinline loop aria-hidden="true"
+        style="position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0;will-change:opacity;transition:opacity 300ms ease;">
+        <source src="/images/hero-video.mp4" type="video/mp4">
+      </video>
+      {{ end }}
+      <div class="absolute top-0 left-0 w-full flex justify-center lg:justify-end z-10">
+        <div class="w-[200px] lg:w-[300px] flex-none pt-3 lg:pr-12">
+          <img src="/images/Logo_unwritten_black_RGB.svg" alt="Unwritten Studio Logo" loading="eager">
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="container max-w-screen-xl mx-auto">
+    <div class="max-w-[780px] mx-auto text-center py-16">
+      <h1 class="text-[#3087b9] text-[2.25rem] lg:text-[2.7rem] font-tertiary font-light mb-4">
+        {{ .title | markdownify }}
+      </h1>
+      <div>
+        <p class="text-[#3e4447] font-tertiary text-lg tracking-wider">{{ .content | markdownify }}</p>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Banner -->
+
+<!-- Features -->
+{{ with .Params.features }}
+<section class="features-section">
+  <div
+    class="relative before:absolute before:w-full before:h-[25%] before:content-[''] before:left-0 before:bottom-0 before:bg-[#3F4448] before:z-0">
+    <div class="container max-w-screen-xl mx-auto">
+      <div class="w-[80%] lg:min-h-[480px] mx-auto relative z-10">
+        {{ partial "image" (dict "Src" .image "Alt" "Banner image" "Loading" "eager" "Class" "w-full h-auto" "DisplayXL"
+        "1060x" ) }}
+      </div>
+    </div>
+  </div>
+  <div class="bg-[#3F4448]">
+    <div class="container max-w-screen-xl mx-auto">
+      <div class="lg:w-[80%] mx-auto pb-8 lg:pb-0">
+        <div class="grid grid-cols-12 gap-y-5 lg:gap-x-5">
+          {{ range .features_list }}
+          <div class="col-span-12 lg:col-span-4">
+            <div class="text-center tracking-wider pt-8 pb-8 lg:pb-24">
+              <h3 class="text-gray-100 text-2xl lg:text-2xl font-tertiary font-light">{{ .title }}</h3>
+              <h4 class="text-[#3087b9] text-lg lg:text-lg font-tertiary font-light">{{ .subtitle }}</h4>
+              <div class="pt-2">
+                <p class="text-base lg:text-base text-gray-100 font-tertiary font-light">{{ .content | markdownify }}
+                </p>
+              </div>
+            </div>
+          </div>
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Features -->
+
+<!-- Quotes -->
+{{ with .Params.quotes }}
+<section class="quotes-section">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-20">
+    <header class="text-center">
+      <h2 class="text-[#3087b9] font-tertiary font-light mb-4">Quotes</h2>
+    </header>
+    <div class="lg:w-[80%] mx-auto pt-6">
+      <div class="swiper testimonial-slider">
+        <div class="swiper-wrapper">
+          {{ range $i, $quote := . }}
+          {{ if eq (mod $i 2) 0 }}
+          <div class="swiper-slide">
+            {{ end }}
+            <div class="text-center first:mb-8">
+              <p class="text-[#3e4447] font-tertiary text-base tracking-wider">{{ $quote.quote }}</p>
+              <div class="pt-4">
+                <h4 class="text-[#3e4447] font-tertiary text-xl font-normal tracking-wider">{{ $quote.name }}</h4>
+                <p class="text-[#3e4447] font-tertiary text-base tracking-wider">{{ $quote.position }}</p>
+              </div>
+            </div>
+            {{ if eq (mod $i 2) 1 }}
+          </div>
+          {{ end }}
+          {{ end }}
+        </div>
+        <div class="testimonial-slider-pagination mt-9 flex items-center justify-center text-center"></div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Quotes -->
+
+<!-- Partners -->
+{{ with .Params.partners }}
+<section class="partners-section bg-[#3F4448]">
+  <div class="container max-w-screen-xl mx-auto pt-16 lg:pt-20">
+    <header class="text-center">
+      <h2 class="text-gray-100 font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div>
+        <p class="text-gray-100 font-tertiary text-lg font-light tracking-wider">{{ .content | markdownify }}</p>
+      </div>
+    </header>
+    <div class="lg:w-[86%] mx-auto pt-12">
+      <div class="grid grid-cols-12">
+        {{ range .partner_logo }}
+        <div class="col-span-4">
+          <div
+            class="w-[86%] md:w-[190px] lg:w-[190px] h-[60px] md:h-[98px] lg:h-[98px] mx-auto bg-[url('/images/Glaskugel.png')] bg-cover bg-no-repeat bg-top flex justify-center items-end pb-4">
+            <div class="w-1/2">
+              {{ partial "image" (dict "Src" .image "Alt" (.alt | default "Partner logo") "Loading" "lazy" "Class" "w-full h-auto"
+              "DisplayXL" "260x" "DisplayMD" "360x" ) }}
+            </div>
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Quotes -->
+
+<!-- /Partners -->
+
+<!-- Anwendungen -->
+{{ with .Params.anwendungen }}
+<section class="anwendungen-section bg-white">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-20">
+    <header class="text-center">
+      <h2 class="text-[#3087b9] font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div>
+        <p class="text-[#3e4447] font-tertiary text-lg tracking-wider">{{ .content | markdownify }}</p>
+      </div>
+    </header>
+    <div class="lg:w-[90%] mx-auto pt-20">
+      <div class="space-y-20 md:space-y-20">
+        {{ range .applications }}
+        <div class="showcase-item flex flex-col md:flex-row items-center md:items-start gap-8">
+          <!-- Text content - appears first on mobile, second on desktop -->
+          <div class="flex-1 text-center md:text-left order-1 md:order-2">
+            <h3 class="font-tertiary text-xl lg:text-2xl font-light mb-3">
+              <a href="{{ .link }}" target="_blank" rel="noopener noreferrer" class="text-[#3087b9] hover:underline">
+                {{ .subtitle }}
+              </a>
+            </h3>
+            <p class="text-[#3e4447] font-tertiary text-sm lg:text-base tracking-wider leading-relaxed">{{ .content }}</p>
+          </div>
+          <!-- Image - appears second on mobile, first on desktop -->
+          <div class="flex-shrink-0 order-2 md:order-1">
+            <div class="w-[70%] mx-auto md:w-[190px] md:mx-0 lg:w-[230px] aspect-[4/3] overflow-hidden rounded">
+              {{ partial "image" (dict "Src" .image "Alt" (.subtitle | default "Showcase") "Loading" "lazy" "Class" "w-full h-full object-cover" "DisplayXL" "230x" "DisplayMD" "190x" ) }}
+            </div>
+          </div>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Anwendungen -->
+
+<!-- Forschungsbereich -->
+{{ with .Params.forschungsbereich }}
+<section class="forschungsbereich-section bg-[#3F4448]">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-24">
+    <header class="text-center">
+      <h2 class="text-gray-100 font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div class="space-y-4">
+        {{ range (split .content "\n") }}
+          <p class="text-gray-100 font-tertiary text-lg font-light tracking-wider">{{ . | markdownify }}</p>
+        {{ end }}
+      </div>
+    </header>
+  </div>
+</section>
+{{ end }}
+<!-- /Forschungsbereich -->
+
+<!-- Microsites -->
+{{ with .Params.microsites }}
+<section class="microsites-section bg-[#f3f4f6]">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-20">
+    <header class="text-center mb-16">
+      <h2 class="text-[#3087b9] font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div>
+        <p class="text-[#3e4447] font-tertiary text-lg tracking-wider max-w-3xl mx-auto">{{ .content | markdownify }}</p>
+      </div>
+    </header>
+
+    <!-- Wegweiser Layout: cards meet at a central vertical pole -->
+    <div class="relative max-w-6xl mx-auto px-6 lg:px-10">
+      <!-- Central pole: visible in the gap between left and right cards -->
+      <div class="hidden lg:block absolute left-1/2 inset-y-0 w-0.5 bg-gray-300 -translate-x-px"></div>
+
+      <div class="space-y-4 lg:space-y-5">
+        {{ range $index, $microsite := .microsites }}
+        <a href="{{ $microsite.url }}" target="_blank" rel="noopener noreferrer" class="group block">
+          {{ if eq (mod $index 2) 0 }}
+            <!-- Left card: ends just before center pole (2% left margin, 47% width → ends at 49%) -->
+            <div class="flex flex-row items-center gap-3 px-4 py-3 rounded bg-white w-full lg:w-[47%] lg:ml-[2%]">
+              <div class="flex-shrink-0 w-[96px] h-[54px] overflow-hidden rounded">
+                <img src="{{ $microsite.image }}" alt="{{ $microsite.name }}" loading="lazy" class="w-full h-full object-cover block">
+              </div>
+              <div class="flex-1 min-w-0">
+                <h3 class="text-[#3087b9] font-tertiary text-base lg:text-lg font-light mb-0.5 group-hover:underline transition-colors">
+                  {{ $microsite.name }}
+                </h3>
+                <p class="text-[#3e4447] font-tertiary text-sm tracking-wider leading-snug">
+                  {{ $microsite.description }}
+                </p>
+              </div>
+            </div>
+          {{ else }}
+            <!-- Right card: starts just after center pole (51% left margin, 47% width → ends at 98%) -->
+            <div class="flex flex-row-reverse lg:flex-row items-center gap-3 px-4 py-3 rounded bg-white w-full lg:w-[47%] lg:ml-[51%]">
+              <div class="flex-1 min-w-0 lg:text-right">
+                <h3 class="text-[#3087b9] font-tertiary text-base lg:text-lg font-light mb-0.5 group-hover:underline transition-colors">
+                  {{ $microsite.name }}
+                </h3>
+                <p class="text-[#3e4447] font-tertiary text-sm tracking-wider leading-snug">
+                  {{ $microsite.description }}
+                </p>
+              </div>
+              <div class="flex-shrink-0 w-[96px] h-[54px] overflow-hidden rounded">
+                <img src="{{ $microsite.image }}" alt="{{ $microsite.name }}" loading="lazy" class="w-full h-full object-cover block">
+              </div>
+            </div>
+          {{ end }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Microsites -->
+
+<!-- Teams -->
+{{ with .Params.teams }}
+<section class="teams-section bg-white">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-24">
+    <header class="text-center">
+      <h2 class="text-[#3087b9] font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div>
+        <p class="text-[#3e4447] font-tertiary text-lg tracking-wider">{{ .content | markdownify }}</p>
+      </div>
+    </header>
+    <div class="lg:w-[84%] mx-auto pt-10">
+      <div class="swiper teams-slider">
+        <div class="swiper-wrapper">
+          {{ range $index, $team := .team }}
+          <div class="swiper-slide relative">
+            <div class="swiper-image">
+              {{ partial "image" (dict "Src" .image "Alt" "Swiper image" "Loading" "eager" "Class" "w-full h-auto" "DisplayXL" "280x" "DisplayMD" "360x" ) }}
+            </div>
+            <div class="team-name absolute left-1/2 transform -translate-x-1/2 top-[105%] md:top-[105%] lg:top-[100%] xl:top-[105%] w-[150%] text-center transition-all duration-200 ease-[ease]">
+              <p class="text-[#3e4447] font-tertiary text-lg tracking-wider mb-2">{{ .name | markdownify }}</p>
+              <p class="text-[#3e4447] font-tertiary text-base tracking-wider whitespace-nowrap">
+                {{ .keywords | replaceRE "<br>" " • " | replaceRE "\n" " • " | markdownify }}
+              </p>
+            </div>
+          </div>
+          {{ end }}
+        </div>
+        <div class="flex justify-center pt-28">
+          <div class="teams-slider-pagination flex items-center justify-center text-center"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Teams -->
+ 
+<!-- Contact -->
+{{ with .Params.contact }}
+<section class="teams-section bg-[#F5F5F5]">
+  <div class="container max-w-screen-xl mx-auto pt-16 pb-16 lg:pt-20 lg:pb-20">
+    <header class="text-center">
+      <h2 class="text-[#3087b9] font-tertiary font-light mb-4">{{ .title | markdownify }}</h2>
+      <div>
+        <p class="text-[#3e4447] font-tertiary text-lg tracking-wider">{{ .content | markdownify }}</p>
+      </div>
+    </header>
+    <div class="lg:w-[80%] mx-auto pt-6">
+      <form action="">
+        <div>
+          <div class="mb-6">
+            <label class="hidden" for="name">Nome*</label>
+            <input
+              class="placeholder:text-[#3e4447] placeholder:font-normal placeholder:text-lg placeholder:leading-tertiary bg-white w-full border border-white px-3 py-[6px] focus:outline-none focus:border-transparent focus:ring-transparent focus:ring-0"
+              type="text" id="name" name="name" placeholder="Dein Name" required="">
+          </div>
+          <div class="mb-6">
+            <label class="hidden" for="email">Email*</label>
+            <input
+              class="placeholder:text-[#3e4447] placeholder:font-normal placeholder:text-lg placeholder:leading-tertiary bg-white w-full border border-white px-3 py-[6px] focus:outline-none focus:border-transparent focus:ring-transparent focus:ring-0"
+              type="email" id="email" name="email" placeholder="Deine E-Mail Adresse" required="">
+          </div>
+          <div class="mb-4">
+            <label class="hidden" for="message">message</label>
+            <textarea
+              class="placeholder:text-[#3e4447] placeholder:font-normal placeholder:text-lg placeholder:leading-tertiary bg-white w-full border border-white px-3 py-[6px] focus:outline-none focus:border-transparent focus:ring-transparent focus:ring-0"
+              type="text" id="message" name="message" placeholder="Deine Nachricht" rows="4" required=""></textarea>
+          </div>
+          <div class="input__checkbox-center">
+            <label class="checkbox-label">
+              <div class="checkbox-group flex items-center space-x-4">
+                <div class="w-[32px] h-[32px] flex-none relative">
+                  <input class="checkbox-input absolute opacity-0 cursor-pointer w-0 h-0" type="checkbox" />
+                  <span
+                    class="checkbox-checkmark absolute top-0 left-0 w-[32px] h-[32px] bg-white cursor-pointer"></span>
+                </div>
+                <div class="flex-1">
+                  <span class="text-[#3e4447] text-sm lg:text-base font-tertiary tracking-wider">l agree to the terms
+                    set out in the privacy
+                    policy.*</span>
+                </div>
+              </div>
+            </label>
+          </div>
+          <div class="pt-6">
+            <button type="submit"
+              class="w-1/2 h-[36px] inline-flex justify-center items-center text-gray-100 font-tertiary tracking-wider bg-[#3F4448]">Submit</button>
+          </div>
+        </div>
+      </form>
+
+    </div>
+  </div>
+</section>
+{{ end }}
+<!-- /Contact -->
+
+{{ end }}


### PR DESCRIPTION
## Summary

- **Banner**: Neuer Einstiegstext — Labor-Metapher statt Produktversprechen
- **Drei Säulen**: Funke / Schmiede / Sog mit neuen Texten und Subtitles (Zündung / Rohbau / Tiefgang)
- **Layout-Override** `layouts/index.html`: Subtitle-Größe auf `text-lg`, Abstand Subtitle→Fließtext auf `pt-2` — erzeugt klare Hierarchie ohne Trennung

## Technische Notiz

`layouts/index.html` ist ein projektlokaler Override der Theme-Datei (`themes/hugoplate/layouts/index.html`). Hugo bevorzugt projektlokale Layouts — das Theme bleibt unberührt.

## Test plan

- [ ] Lokal geprüft auf http://localhost:1313
- [ ] Banner-Text korrekt
- [ ] Drei Säulen: Titel, Subtitle, Body stimmen
- [ ] Typografie-Hierarchie (Titel > Subtitle > Body) visuell harmonisch

🤖 Generated with [Claude Code](https://claude.com/claude-code)